### PR TITLE
Implement support for the insert_position admin setting.

### DIFF
--- a/app/code/community/SomethingDigital/RecentlyViewed/Model/Adminhtml/System/Config/SdRecentlyViewedPosition.php
+++ b/app/code/community/SomethingDigital/RecentlyViewed/Model/Adminhtml/System/Config/SdRecentlyViewedPosition.php
@@ -6,10 +6,10 @@ class SomethingDigital_RecentlyViewed_Model_Adminhtml_System_Config_sdRecentlyVi
        $position = array(
            array( 'value' => 'top',    'label' => 'Top'    ),
            array( 'value' => 'bottom', 'label' => 'Bottom' ),
-           array( 'value' => 'above',  'label' => 'Above'  ),
-           array( 'value' => 'below',  'label' => 'Below'  ),
+           array( 'value' => 'before',  'label' => 'Above'  ),
+           array( 'value' => 'after',  'label' => 'Below'  ),
        );
- 
+
        return $position;
    }
 }

--- a/app/design/frontend/base/default/template/sd_recentlyviewed/productid.phtml
+++ b/app/design/frontend/base/default/template/sd_recentlyviewed/productid.phtml
@@ -1,4 +1,4 @@
-<?php 
+<?php
 $product    = Mage::registry('current_product');
 $category   = Mage::registry('current_category');
 $productId  = $product ? $product->getId() : null;
@@ -9,6 +9,7 @@ window.sdRecentlyViewed = {
 	productId: '<?php echo $productId; ?>',
 	categoryId: '<?php echo $categoryId; ?>',
 	maxDisplay: '<?php echo Mage::getStoreConfig('catalog/recently_products/viewed_count');?>',
-	insertAt: '<?php echo Mage::getStoreConfig('catalog/recently_products/insert_at');?>'
+	insertAt: '<?php echo Mage::getStoreConfig('catalog/recently_products/insert_at');?>',
+	insertPosition: '<?php echo Mage::getStoreConfig('catalog/recently_products/insert_position');?>'
 }
 </script>

--- a/skin/frontend/base/default/js/sd_recentlyviewed/recent.js
+++ b/skin/frontend/base/default/js/sd_recentlyviewed/recent.js
@@ -79,11 +79,16 @@ SomethingDigitalRecentlyViewed.prototype = {
 			return;
 		}
 
-		var html = rvTemplate.innerHTML.replace('{{items}}',this.getRenderedItems());
-		$(target).insert({top: html});
+		var insertParams = {}, //to enable use of variable keys (i.e. $position: content)
+			insertPosition = sdRecentlyViewed.insertPosition,
+			html = rvTemplate.innerHTML.replace('{{items}}',this.getRenderedItems());
+
+		insertParams[insertPosition] = html;
+
+		$(target).insert(insertParams);
 
 	}
-}
+};
 
 document.observe('dom:loaded',function(){
 	new SomethingDigitalRecentlyViewed();


### PR DESCRIPTION
I noticed that despite `SomethingDigital_RecentlyViewed_Model_Adminhtml_System_Config_sdRecentlyViewedPosition` seeming to allude support for the `catalog/recently_products/insert_position` config field, the position was actually hardcoded to "top" in the JS that places the content.

This change implements actual support for that field, mapping "Above/Below" to "Before/After" for Prototype's `.insert()`.
