### PR TITLE
Add config field to sort the render as newest to oldest (opposite of …

### DIFF
--- a/app/code/community/SomethingDigital/RecentlyViewed/Model/Adminhtml/System/Config/SdRecentlyViewedSortOrder.php
+++ b/app/code/community/SomethingDigital/RecentlyViewed/Model/Adminhtml/System/Config/SdRecentlyViewedSortOrder.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @category SomethingDigital
+ * @package  SomethingDigital_RecentlyViewed
+ * @author   Robert Robinson <robr3rd@gmail.com>
+ */
+class SomethingDigital_RecentlyViewed_Model_Adminhtml_System_Config_sdRecentlyViewedSortOrder
+{
+	/**
+	 * Configure frontend field for `catalog/recently_products/sort_order`
+	 * @return array Map for field's label->value
+	 */
+	 public function toOptionArray()
+	 {
+		$position = [
+			['value'=>'oldnew', 'label'=>'Oldest-Newest'],
+			['value'=>'newold', 'label'=>'Newest-Oldest'],
+		];
+
+		return $position;
+	 }
+}

--- a/app/code/community/SomethingDigital/RecentlyViewed/etc/system.xml
+++ b/app/code/community/SomethingDigital/RecentlyViewed/etc/system.xml
@@ -1,31 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-    <sections>
-        <catalog>
-            <groups>
-                <recently_products>
-                    <fields>
-                        <insert_at translate="label">
-                            <label>Recently Viewed Container</label>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>100</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <comment><![CDATA[NOTICE: Must be valid CSS selector]]></comment>
-                        </insert_at>
-                        <insert_position translate="label">
-                            <label>Recently Viewed Container Position</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>SomethingDigital_RecentlyViewed_Model_Adminhtml_System_Config_sdRecentlyViewedPosition</source_model>
-                            <sort_order>200</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </insert_position>
-                    </fields>
-                </recently_products>
-            </groups>
-        </catalog>
-    </sections>
+	<sections>
+		<catalog>
+			<groups>
+				<recently_products>
+					<fields>
+						<insert_at translate="label">
+							<label>Recently Viewed Container</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>100</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<comment><![CDATA[NOTICE: Must be valid CSS selector]]></comment>
+						</insert_at>
+						<insert_position translate="label">
+							<label>Recently Viewed Container Position</label>
+							<frontend_type>select</frontend_type>
+							<source_model>SomethingDigital_RecentlyViewed_Model_Adminhtml_System_Config_sdRecentlyViewedPosition</source_model>
+							<sort_order>200</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</insert_position>
+						<sort_order translate="label">
+							<label>Recently Viewed Container Sort Order</label>
+							<frontend_type>select</frontend_type>
+							<source_model>SomethingDigital_RecentlyViewed_Model_Adminhtml_System_Config_sdRecentlyViewedSortOrder</source_model>
+							<sort_order>300</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</sort_order>
+					</fields>
+				</recently_products>
+			</groups>
+		</catalog>
+	</sections>
 </config>

--- a/skin/frontend/base/default/js/sd_recentlyviewed/recent.js
+++ b/skin/frontend/base/default/js/sd_recentlyviewed/recent.js
@@ -61,9 +61,18 @@ SomethingDigitalRecentlyViewed.prototype = {
 	getRenderedItems: function(){
 		var items = this.getLoadedStorage();
 
-		return items.map(function(a){
+		if(sdRecentlyViewed.sortOrder === 'newold'){
+			var reversedItems = items;
+			reversedItems.reverse();
+
+			return reversedItems.map(function(a){
 				return a.html;
 			}).join('');
+		}
+
+		return items.map(function(a){
+			return a.html;
+		}).join('');
 	},
 
 	render: function(){


### PR DESCRIPTION
…default). Current functionality (oldest to newest) remains the default behavior.
