### PR TITLE
feature/bugfixes empty block null product

### DIFF
--- a/skin/frontend/base/default/js/sd_recentlyviewed/recent.js
+++ b/skin/frontend/base/default/js/sd_recentlyviewed/recent.js
@@ -81,7 +81,7 @@ SomethingDigitalRecentlyViewed.prototype = {
 
 	render: function(){
 
-		if(!this.items || this.items.length < 1){
+		if(!this.items || this.items.length <= 1){
 			return;
 		}
 

--- a/skin/frontend/base/default/js/sd_recentlyviewed/recent.js
+++ b/skin/frontend/base/default/js/sd_recentlyviewed/recent.js
@@ -57,7 +57,7 @@ SomethingDigitalRecentlyViewed.prototype = {
 			}
 
 		//move to end if current product *is* in unique keys
-		} else {
+		} else if (index != -1) {
 			var obj = recentlyViewed.splice(index, 1)[0];
 			recentlyViewed.push(obj);
 		}


### PR DESCRIPTION
Some additional fixes for bugs:
- Stop rendering empty block when only one product present in the recentlyViewed array
- Stop adding a "null" value to array when no product is present to add to the recentlyViewed array
